### PR TITLE
Update makesharedlib.sh

### DIFF
--- a/makesharedlib.sh
+++ b/makesharedlib.sh
@@ -6,7 +6,7 @@ sed 's/CFLAGS = -O3 -fomit-frame-pointer/CFLAGS = -O3 -fPIC -fomit-frame-pointer
 echo "rebuilding libcuba.a archive"
 make -B libcuba.a
 echo "unpacking libcuba.a"
-FILES=$(ar xv libcuba.a |sed 's/x - //g')
+FILES=$(ar xv libcuba.a |sed 's/x - //g'|grep -v ' __\.SYMDEF SORTED__')
 echo "making libcuba.so"
 echo gcc -shared -Wall -lm $FILES -o libcuba.so
 gcc -shared -Wall -lm $FILES -o libcuba.so


### PR DESCRIPTION
I had a problem while building the cuba shared library, I got an error after typing "./makesharedlib.sh".
The problem comes from the file __.SYMDEF SORTED which is not found.

This is a pull request to grep out " __.SYMDEF SORTED__" as @JohannesBuchner suggested in issue #117 from pyMultinest.